### PR TITLE
GameObjectCollection to return optional array

### DIFF
--- a/sample/types/GameObjectCollection.lua
+++ b/sample/types/GameObjectCollection.lua
@@ -44,7 +44,7 @@ end
 --- Get array of game objects by type.
 ---@generic T:GameObject
 ---@param type T
----@return T[]
+---@return T[]|nil
 function GameObjectCollection:gameObjectArray(type)
     return self.objects[type]
 end

--- a/src/types/GameObjectCollection.lua
+++ b/src/types/GameObjectCollection.lua
@@ -44,7 +44,7 @@ end
 --- Get array of game objects by type.
 ---@generic T:GameObject
 ---@param type T
----@return T[]
+---@return T[]|nil
 function GameObjectCollection:gameObjectArray(type)
     return self.objects[type]
 end


### PR DESCRIPTION
Modification to the engine with `GameObjectCollection.gameObjectArray` to include optional return annotation to highlight errors when nil checks are not added.

Otherwise a runtime error might occur when the method can't return an array of objects for which a key doesn't exist.

**Consider:** is it worth returning an empty array to prevent checks for nil array in `Game.Rules.updateWorld` and `Layouter.layoutObjectsIntoViewHierarchy`? #16 