### PR TITLE
Game controller extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,13 @@ New Kingdoms is distributed as template code in [`/src`](/src) folder. It is ver
 
 You can find a working example in the [`/sample`](/sample) folder and run its code with `love sample` (if you cloned the repo as is). You do not need to copy the `sample` folder together with `src` into your own project.
 
-Note: if you open the repo root folder in an IDE like VSCode with both `src` and `sample` being part of one workspace, the Lua Language Server will issue warnings for duplicate definitions. There are a few options to workaround this:
-1. Do nothing. You can safely ignore the warnings.
-2. Use a preset [`.vscode/settings.json`](/.vscode/settings.json) that skips `sample` from being diagnosed, and uses it as a default running target.
-3. Open a [multi-root workspace](https://code.visualstudio.com/docs/editor/multi-root-workspaces) and add `src` and `sample` separately. Each of them will be correctly diagnosed.
+#### Known issues: 
+- The sample is based on version 0.1 and will be updated only at 1.0 release. It will work, but the engine code is not the latest.
+
+- If you open the repo root folder in an IDE like VSCode with both `src` and `sample` being part of one workspace, the Lua Language Server will issue warnings for duplicate definitions. There are a few options to workaround this:
+    1. Do nothing. You can safely ignore the warnings.
+    2. Use a preset [`.vscode/settings.json`](/.vscode/settings.json) that skips `sample` from being diagnosed, and uses it as a default running target.
+    3. Open a [multi-root workspace](https://code.visualstudio.com/docs/editor/multi-root-workspaces) and add `src` and `sample` separately. Each of them will be correctly diagnosed.
  
 ## Prerequisites
 To create games with New Kingdoms you will need LÖVE framework, VS Code, and Lua Language Server. Instructions here are provided for macOS, but it will work on Linux and Windows as well.

--- a/docs/pages/samples.md
+++ b/docs/pages/samples.md
@@ -7,6 +7,8 @@ nav_order: 3
 # Samples
 You can find a demo project in the [GitHub repository](https://github.com/kujunda-seda/new-kingdoms/tree/master/sample) and see all the required changes by comparing it with the engine (diff with the `src` folder).
 
+The sample is based on version 0.1 and will be updated only at 1.0 release. It will work, but the engine code is not the latest.
+
 The changes to engine are:
 1. **PlaceholderObject** is modified to create `Car` and `Stage` objects.
 2. **PlaceholderView** is modified to create respective `CarView` and `StageView` views.

--- a/src/game/Engine.lua
+++ b/src/game/Engine.lua
@@ -1,14 +1,14 @@
 local GameRules = require "game.GameRules"
 local GameObjectCollection = require "types.GameObjectCollection"
 
----Manages game objects and relationships between them, e.g. creating scenes.
----@class GameEngine
+--- Manages main game engine loop (start, update, stop).
+---@class Engine
 ---@field private gameWorld GameObjectCollection All objects of the game universe.
 ---@field private gameObjectsChanged function? Callback to react on changes.
-local GameEngine = {}
+local Engine = {}
 
----@return GameEngine
-function GameEngine:new()
+---@return Engine
+function Engine:new()
     -- Required code for instances to find defined methods and inheritance
     local newObject = setmetatable({}, self)
     self.__index = self
@@ -21,22 +21,22 @@ end
 
 --- Starts a game engine and assigns callback to be called when objects change.
 ---@param listener function Callback function to be called when relayout is required
-function GameEngine:startWithObjectListener(listener)
+function Engine:startWithObjectListener(listener)
     self.gameWorld = GameRules:createWorld()
     self.gameObjectsChanged = listener
 end
 
-function GameEngine:stop()
+function Engine:stop()
     self.gameObjectsChanged = nil
 end
 
 --- Triggers game engine time shift.
 ---@param dt number Time difference from previous similar event in game time
-function GameEngine:timePassed(dt)
+function Engine:timePassed(dt)
     -- default scenario: platform time = game time
     GameRules:updateWorld(self.gameWorld, dt)
 
-    -- run callback to presenter
+    -- run callback to presenter with each time increment
     if self.gameObjectsChanged ~= nil then
         self:gameObjectsChanged()
     end
@@ -44,16 +44,9 @@ end
 
 --- Returns viewable game objects grouped by type for easier parsing.
 ---@return GameObjectCollection
-function GameEngine:getViewableObjects()
+function Engine:getViewableObjects()
     -- default scenario: returns all objects of the universe
     return self.gameWorld
 end
 
---- Propagates touch event to the engine.
----@param object GameObject
-function GameEngine:objectInteracted(object)
-    -- default scenario: channel / responder-chain all events to objects
-    object:objectInteracted()
-end
-
-return GameEngine
+return Engine

--- a/src/game/GameController.lua
+++ b/src/game/GameController.lua
@@ -1,0 +1,26 @@
+local ViewPair = require "types.ViewPair"
+
+--- Converts interaction events into meaningful object actions.
+---@class GameController
+local GameController = {}
+
+---@return GameController
+function GameController:new()
+    -- Required code for instances to find defined methods and inheritance
+    local newObject = setmetatable({}, self)
+    self.__index = self
+
+    return newObject
+end
+
+--- Processes the touch by invoking an object action.
+---@param viewPair ViewPair intersected view-object pair
+---@param x number global x-coordinate
+---@param y number global y-coordinate
+---@return boolean isProcessed returns true if the event was processed and shoudn't be forwarded.
+function GameController:processTouchFor(viewPair, x, y)
+    local type = viewPair.object:class()
+    return true
+end
+
+return GameController

--- a/src/main.lua
+++ b/src/main.lua
@@ -3,7 +3,7 @@ local Presenter = require "presenter.Presenter"
 local presenter = Presenter:new()
 
 function love.load()
-    presenter:startGameEngine()
+    presenter:startEngine()
 end
 
 function love.update(dt)
@@ -16,9 +16,9 @@ end
 
 -- `mousepressed` works both for macOS and iOS
 function love.mousepressed(x, y, button, istouch, presses)
-    presenter:attributeTouchToObject(x, y)
+    presenter:attributeTouch(x, y)
 end
 
 function love.quit()
-    presenter:stopGameEngine()
+    presenter:stopEngine()
 end

--- a/src/presenter/GameLayout.lua
+++ b/src/presenter/GameLayout.lua
@@ -6,10 +6,17 @@ local PlaceholderView = require "views.PlaceholderView"
 local PlaceholderObject = require "objects.PlaceholderObject"
 
 --- Visually maps supplied game objects into views.
----@class Layouter
-local Layouter = {}
+---@class GameLayout
+local GameLayout = {}
 
--- Only class methods are used, therefore no constructor for instances exists.
+---@return GameLayout
+function GameLayout:new()
+    -- Required code for instances to find defined methods and inheritance
+    local newObject = setmetatable({}, self)
+    self.__index = self
+
+    return newObject
+end
 
 -- Constants
 -- [Provide constants for layouting]
@@ -17,7 +24,7 @@ local Layouter = {}
 --- Creates view hierarchy with configured views and links them to corresponding objects.
 ---@param objects GameObjectCollection Type-associative table of indexed game objects
 ---@return ViewPair[] viewHierarchy A z-indexed table of view:object pairs
-function Layouter.layoutObjectsIntoViewHierarchy(objects)
+function GameLayout:layoutObjectsIntoViewHierarchy(objects)
 
     ---@type ViewPair[]
     local viewHierarchy = {}
@@ -38,4 +45,4 @@ function Layouter.layoutObjectsIntoViewHierarchy(objects)
     return viewHierarchy
 end
 
-return Layouter
+return GameLayout

--- a/src/types/GameObject.lua
+++ b/src/types/GameObject.lua
@@ -13,6 +13,12 @@ function GameObject:new(object)
     return newObject
 end
 
+--- Returns specific class of object.
+---@return GameObject class class object
+function GameObject:class()
+    return getmetatable(self)
+end
+
 --- Notifies object of interaction.
 function GameObject:objectInteracted() end
 

--- a/src/types/GameObjectCollection.lua
+++ b/src/types/GameObjectCollection.lua
@@ -19,20 +19,11 @@ function GameObjectCollection:new()
     return newObject
 end
 
---- Get class of an instance
----@param object GameObject
----@return GameObject class
----@private
-local function get_class(object)
-    return getmetatable(object)
-end
-
 --- Insert object of type
----@generic T:GameObject
----@param object T
+---@param object GameObject
 function GameObjectCollection:insertObject(object)
 
-    local type = get_class(object)
+    local type = object:class()
     local arrayOfObjects = self:gameObjectArray(type)
     if not arrayOfObjects then
         self.objects[type] = {}

--- a/src/types/View.lua
+++ b/src/types/View.lua
@@ -17,8 +17,8 @@ end
 function View:draw() end
 
 --- Checks if touch was made within view boundaries.
----@param x number
----@param y number
+---@param x number global x-coordinate
+---@param y number global y-coordinate
 ---@return boolean
 function View:touchInside(x, y) return false end
 

--- a/src/types/ViewPair.lua
+++ b/src/types/ViewPair.lua
@@ -20,4 +20,14 @@ function ViewPair:new(view, object)
     return newObject
 end
 
+--- Cast view pair's types.
+---@generic TV:View
+---@generic TO:GameObject
+---@param viewClass TV view type
+---@param objectClass TO object type
+---@return TV, TO
+function ViewPair:cast(viewClass, objectClass)
+    return self.view, self.object
+end
+
 return ViewPair


### PR DESCRIPTION
Closes #18 (description in the issue)

- `GameController` is now responsible for touch attribution
- `Engine` has single responsibility to start/update/stop
- `GameLayout` is converted to be used as object
- `class` and `cast` helpers are added.